### PR TITLE
sax/streaming json refactoring

### DIFF
--- a/gtest/parsers/test_stream.cpp
+++ b/gtest/parsers/test_stream.cpp
@@ -23,7 +23,7 @@ struct TestObject {
   }
 };
 
-using parser = tgbm::json::stream_parser<>;
+using parser = tgbm::json::stream_parser;
 
 TEST(StreamParsing, Int) {
   TestObject expected{.int_field = {1}};

--- a/include/tgbm/api/requests.hpp
+++ b/include/tgbm/api/requests.hpp
@@ -103,7 +103,7 @@ template <tgapi_request R>
 dd::task<reqerr_t> send_request(const R& request, http_client& client, const const_string& bottoken,
                                 request_return_t<R>& out, deadline_t deadline) {
   telegram_answer r(out);
-  json::stream_parser<> parser(r);
+  json::stream_parser parser(r);
   io_error_code ec;
   auto parse_to_out = [&](std::span<const byte_t> bytes, bool last_part) {
     parser.feed(std::string_view((const char*)bytes.data(), bytes.size()), last_part, ec);

--- a/include/tgbm/api/telegram_answer.hpp
+++ b/include/tgbm/api/telegram_answer.hpp
@@ -29,8 +29,7 @@ namespace tgbm::generator_parser {
 
 template <typename T>
 struct boost_domless_parser<api::telegram_answer<T>> {
-  static dd::generator<dd::nothing_t> parse(api::telegram_answer<T>& out, event_holder& tok,
-                                            generator_parser::memres_tag auto resource) {
+  static dd::generator<dd::nothing_t> parse(api::telegram_answer<T>& out, event_holder& tok) {
     using enum event_holder::wait_e;
     tok.expect(object_begin);
 
@@ -65,14 +64,14 @@ struct boost_domless_parser<api::telegram_answer<T>> {
           out.ok = tok.bool_m;
           continue;
         case result_key:
-          co_yield dd::elements_of(boost_domless_parser<T>::parse(out.result, tok, resource));
+          co_yield dd::elements_of(boost_domless_parser<T>::parse(out.result, tok));
           continue;
         case description_key:
           tok.expect(string);
           out.description = tok.str_m;
           continue;
         case unknown_key:
-          co_yield dd::elements_of(ignore_parser::parse(tok, resource));
+          co_yield dd::elements_of(ignore_parser::parse(tok));
           continue;
       }
     }
@@ -85,15 +84,14 @@ struct boost_domless_parser<api::telegram_answer<T>> {
 // for parsing return type of some operations
 template <>
 struct boost_domless_parser<tgbm::box_union<bool, tgbm::api::Message>> {
-  static dd::generator<dd::nothing_t> parse(tgbm::box_union<bool, tgbm::api::Message>& out, event_holder& tok,
-                                            generator_parser::memres_tag auto resource) {
+  static dd::generator<dd::nothing_t> parse(tgbm::box_union<bool, tgbm::api::Message>& out,
+                                            event_holder& tok) {
     using enum event_holder::wait_e;
     if (tok.got == bool_) {
       out = tok.bool_m;
       return {};
     }
-    return boost_domless_parser<api::Message>::parse(out.emplace<tgbm::api::Message>(), tok,
-                                                     std::move(resource));
+    return boost_domless_parser<api::Message>::parse(out.emplace<tgbm::api::Message>(), tok);
   }
 };
 

--- a/include/tgbm/tools/json_tools/generator_parser/basic_parser.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/basic_parser.hpp
@@ -48,16 +48,10 @@ struct event_holder {
   }
 };
 
-// cannot be used now because of gcc internal error in send_request
-struct placeholder_resource {};
-template <typename T>
-concept memres_tag =
-    std::same_as<std::decay_t<T>, placeholder_resource>;  // dd::last_is_memory_resource_tag<std::decay_t<T>>;
-
 template <typename T>
 struct boost_domless_parser {
   // required interface:
-  //   dd::generator<nothing_t> parse(T& v, event_holder& tok, memres_tag auto)
+  //   dd::generator<nothing_t> parse(T& v, event_holder& tok)
 };
 
 }  // namespace tgbm::generator_parser

--- a/include/tgbm/tools/json_tools/generator_parser/common_api.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/common_api.hpp
@@ -27,7 +27,7 @@ struct boost_domless_parser<T> {
   }
 
   static dd::generator<nothing_t> generator_field(T& v, std::string_view key, event_holder& tok,
-                                                  std::bitset<N>& parsed_, memres_tag auto resource) {
+                                                  std::bitset<N>& parsed_) {
     if constexpr (N > 0) {
       return pfr_extension::visit_struct_field<T, dd::generator<nothing_t>>(
           key,
@@ -36,16 +36,15 @@ struct boost_domless_parser<T> {
             if (parsed_.test(I))
               TGBM_JSON_PARSE_ERROR;
             parsed_.set(I);
-            return boost_domless_parser<pfr_extension::tuple_element_t<I, T>>::parse(field, tok,
-                                                                                     std::move(resource));
+            return boost_domless_parser<pfr_extension::tuple_element_t<I, T>>::parse(field, tok);
           },
-          [&]() { return ignore_parser::parse(tok, std::move(resource)); });
+          [&]() { return ignore_parser::parse(tok); });
     } else {
-      return ignore_parser::parse(tok, std::move(resource));
+      return ignore_parser::parse(tok);
     }
   }
 
-  static dd::generator<nothing_t> parse(T& v, event_holder& tok, memres_tag auto resource) {
+  static dd::generator<nothing_t> parse(T& v, event_holder& tok) {
     using enum event_holder::wait_e;
     std::bitset<N> parsed_;
     tok.expect(object_begin);
@@ -57,7 +56,7 @@ struct boost_domless_parser<T> {
       tok.expect(key);
       std::string_view cur_key = tok.str_m;
       co_yield {};
-      co_yield dd::elements_of(generator_field(v, cur_key, tok, parsed_, resource));
+      co_yield dd::elements_of(generator_field(v, cur_key, tok, parsed_));
     }
     if (!all_parsed(parsed_)) [[unlikely]]
       TGBM_JSON_PARSE_ERROR;

--- a/include/tgbm/tools/json_tools/generator_parser/discriminated_api.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/discriminated_api.hpp
@@ -7,19 +7,17 @@ namespace tgbm::generator_parser {
 
 template <discriminated_api_type T>
 struct boost_domless_parser<T> {
-  static dd::generator<nothing_t> get_generator_suboneof(std::string_view key, T& v, event_holder& tok,
-                                                         memres_tag auto resource) {
+  static dd::generator<nothing_t> get_generator_suboneof(std::string_view key, T& v, event_holder& tok) {
     auto emplacer = [&]<typename Suboneof>() -> dd::generator<nothing_t> {
       if constexpr (!std::same_as<Suboneof, void>)
-        return boost_domless_parser<Suboneof>::parse(v.data.template emplace<Suboneof>(), tok,
-                                                     std::move(resource));
+        return boost_domless_parser<Suboneof>::parse(v.data.template emplace<Suboneof>(), tok);
       else
         TGBM_JSON_PARSE_ERROR;
     };
     return v.discriminate(key, emplacer);
   }
 
-  static dd::generator<nothing_t> parse(T& v, event_holder& tok, memres_tag auto resource) {
+  static dd::generator<nothing_t> parse(T& v, event_holder& tok) {
     using enum event_holder::wait_e;
     tok.expect(object_begin);
     co_yield {};
@@ -32,7 +30,7 @@ struct boost_domless_parser<T> {
     tok.expect(string);
     // change 'got' before generator creation (may be function returning generator)
     tok.got = object_begin;
-    co_yield dd::elements_of(get_generator_suboneof(tok.str_m, v, tok, resource));
+    co_yield dd::elements_of(get_generator_suboneof(tok.str_m, v, tok));
   }
 };
 

--- a/include/tgbm/tools/json_tools/generator_parser/fundamental.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/fundamental.hpp
@@ -10,7 +10,7 @@ namespace tgbm::generator_parser {
 
 template <>
 struct boost_domless_parser<bool> {
-  static dd::generator<nothing_t> parse(bool& v, event_holder& tok, memres_tag auto&&) {
+  static dd::generator<nothing_t> parse(bool& v, event_holder& tok) {
     tok.expect(event_holder::bool_);
     v = tok.bool_m;
     return {};
@@ -19,7 +19,7 @@ struct boost_domless_parser<bool> {
 
 template <>
 struct boost_domless_parser<api::True> {
-  static dd::generator<nothing_t> parse(api::True&, event_holder& tok, memres_tag auto&&) {
+  static dd::generator<nothing_t> parse(api::True&, event_holder& tok) {
     if (tok.got != event_holder::bool_ || !tok.bool_m) [[unlikely]]
       TGBM_JSON_PARSE_ERROR;
     return {};
@@ -28,7 +28,7 @@ struct boost_domless_parser<api::True> {
 
 template <>
 struct boost_domless_parser<std::string> {
-  static dd::generator<nothing_t> parse(std::string& v, event_holder& tok, memres_tag auto&&) {
+  static dd::generator<nothing_t> parse(std::string& v, event_holder& tok) {
     tok.expect(event_holder::string);
     v = tok.str_m;
     return {};
@@ -37,7 +37,7 @@ struct boost_domless_parser<std::string> {
 
 template <>
 struct boost_domless_parser<tgbm::const_string> {
-  static dd::generator<nothing_t> parse(tgbm::const_string& v, event_holder& tok, memres_tag auto&&) {
+  static dd::generator<nothing_t> parse(tgbm::const_string& v, event_holder& tok) {
     tok.expect(event_holder::string);
     v = tok.str_m;
     return {};
@@ -47,7 +47,7 @@ struct boost_domless_parser<tgbm::const_string> {
 template <typename T>
   requires(std::integral<T> || std::same_as<api::Integer, T>)
 struct boost_domless_parser<T> {
-  static dd::generator<nothing_t> parse(T& v, event_holder& tok, memres_tag auto&&) {
+  static dd::generator<nothing_t> parse(T& v, event_holder& tok) {
     using enum event_holder::wait_e;
     switch (tok.got) {
       case int64:
@@ -65,7 +65,7 @@ struct boost_domless_parser<T> {
 template <typename T>
   requires(std::floating_point<T> || std::same_as<api::Double, T>)
 struct boost_domless_parser<T> {
-  static dd::generator<nothing_t> parse(T& v, event_holder& tok, memres_tag auto&&) {
+  static dd::generator<nothing_t> parse(T& v, event_holder& tok) {
     tok.expect(event_holder::double_);
     v = tok.double_m;
     return {};

--- a/include/tgbm/tools/json_tools/generator_parser/ignore_parser.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/ignore_parser.hpp
@@ -18,7 +18,7 @@ struct ignore_parser {
     }
   }
 
-  static dd::generator<nothing_t> parse(event_holder& holder, memres_tag auto) {
+  static dd::generator<nothing_t> parse(event_holder& holder) {
     if (is_value(holder))
       co_return;
     std::size_t depth = 0;

--- a/include/tgbm/tools/json_tools/generator_parser/optional_parser.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/optional_parser.hpp
@@ -10,10 +10,10 @@ template <typename Optional>
 struct basic_optional_parser {
   using T = typename Optional::value_type;
 
-  static dd::generator<nothing_t> parse(Optional& v, event_holder& tok, memres_tag auto resource) {
+  static dd::generator<nothing_t> parse(Optional& v, event_holder& tok) {
     if (tok.got == event_holder::null) [[unlikely]]
       return {};
-    return boost_domless_parser<T>::parse(v.emplace(), tok, std::move(resource));
+    return boost_domless_parser<T>::parse(v.emplace(), tok);
   }
 };
 

--- a/include/tgbm/tools/json_tools/generator_parser/vector_parser.hpp
+++ b/include/tgbm/tools/json_tools/generator_parser/vector_parser.hpp
@@ -6,14 +6,13 @@ namespace tgbm::generator_parser {
 
 template <typename T>
 struct boost_domless_parser<std::vector<T>> {
-  static dd::generator<nothing_t> parse(std::vector<T>& v, tgbm::generator_parser::event_holder& tok,
-                                        memres_tag auto resource) {
+  static dd::generator<nothing_t> parse(std::vector<T>& v, tgbm::generator_parser::event_holder& tok) {
     tok.expect(event_holder::array_begin);
     for (;;) {
       co_yield {};
       if (tok.got == event_holder::array_end)
         break;
-      co_yield dd::elements_of(boost_domless_parser<T>::parse(v.emplace_back(), tok, resource));
+      co_yield dd::elements_of(boost_domless_parser<T>::parse(v.emplace_back(), tok));
     }
   }
 };

--- a/include/tgbm/tools/json_tools/stream_parser.hpp
+++ b/include/tgbm/tools/json_tools/stream_parser.hpp
@@ -7,12 +7,11 @@
 
 namespace tgbm::json {
 
-template <typename R = generator_parser::placeholder_resource>
 struct stream_parser {
-  ::boost::json::basic_parser<boost::details::wait_handler<R>> p;
+  ::boost::json::basic_parser<boost::details::wait_handler> p;
 
   template <typename T>
-  explicit stream_parser(T& t, R resource = R{}) : p(::boost::json::parse_options{}, t, std::move(resource)) {
+  explicit stream_parser(T& t) : p(::boost::json::parse_options{}, t) {
   }
 
   void feed(std::string_view data, bool end) {
@@ -36,14 +35,14 @@ struct stream_parser {
 
 template <typename T>
 void from_json(std::string_view json, T& out) {
-  stream_parser p(out, generator_parser::placeholder_resource{});
+  stream_parser p(out);
   p.feed(json, true);
 }
 
 template <typename T>
 T from_json(std::string_view json) {
   T out;
-  from_json(json, out, generator_parser::placeholder_resource{});
+  from_json(json, out);
   return out;
 }
 


### PR DESCRIPTION
refactoring SAX json parser, 

Also adds stack memory resource, but it cannot be applied now because of GCC-14 internal error in send_request (telegram.cpp)

benchmark results now:

```
SimpleUser [ignore_handler_rapid]            775 ns          750 ns       896000
SimpleUser [ignore_handler_boost]            307 ns          305 ns      2357895
SimpleUser [dom_rapid]                      1659 ns         1639 ns       448000
SimpleUser [dom_boost]                      1703 ns         1688 ns       407273
SimpleUser [handler_rapid]                  1619 ns         1569 ns       448000
SimpleUser [handler_boost]                  1168 ns         1123 ns       640000
SimpleUser [generator_boost]                 581 ns          558 ns      1120000
SimpleUser [stream_parser]                   581 ns          562 ns      1000000
SmallMessage [ignore_handler_rapid]          272 ns          267 ns      2635294
SmallMessage [ignore_handler_boost]          162 ns          159 ns      3733333
SmallMessage [dom_rapid]                    2329 ns         2093 ns       298667
SmallMessage [dom_boost]                    2080 ns         2093 ns       373333
SmallMessage [handler_rapid]                1039 ns         1025 ns       640000
SmallMessage [handler_boost]                 976 ns          952 ns       640000
SmallMessage [generator_boost]               669 ns          670 ns      1120000
SmallMessage [stream_parser]                 682 ns          656 ns      1120000
MediumMessage [ignore_handler_rapid]         998 ns          977 ns       640000
MediumMessage [ignore_handler_boost]         450 ns          449 ns      1600000
MediumMessage [dom_rapid]                   4514 ns         4492 ns       160000
MediumMessage [dom_boost]                   4478 ns         4395 ns       160000
MediumMessage [handler_rapid]               4594 ns         4653 ns       154483
MediumMessage [handler_boost]               4102 ns         3861 ns       165926
MediumMessage [generator_boost]             1735 ns         1423 ns       560000
MediumMessage [stream_parser]               1696 ns         1674 ns       373333
HardMessage [ignore_handler_rapid]         34507 ns        34494 ns        19478
HardMessage [ignore_handler_boost]         20032 ns        19566 ns        40727
HardMessage [dom_rapid]                    89076 ns        90681 ns         8960
HardMessage [dom_boost]                   181062 ns       180303 ns         4073
HardMessage [handler_rapid]               107795 ns       108812 ns         7467
HardMessage [handler_boost]                90219 ns        87887 ns         7467
HardMessage [generator_boost]              76476 ns        75335 ns        11200
HardMessage [stream_parser]                83709 ns        85449 ns         8960
Tree [ignore_handler_rapid]             10551239 ns     10498047 ns           64
Tree [ignore_handler_boost]              3820297 ns      3766026 ns          195
Tree [dom_rapid]                        28831696 ns     24639423 ns           26
Tree [dom_boost]                        41274500 ns     40798611 ns           18
Tree [handler_rapid]                    21258319 ns     20996094 ns           32
Tree [handler_boost]                    14908414 ns     15000000 ns           50
Tree [generator_boost]                  16058844 ns     16387195 ns           41
Tree [stream_parser]                    22558044 ns     20996094 ns           32
Nesting [ignore_handler_rapid]              1614 ns         1535 ns       407273
Nesting [ignore_handler_boost]               921 ns          900 ns       746667
Nesting [dom_rapid]                         3572 ns         3516 ns       213333
Nesting [dom_boost]                         5813 ns         5720 ns       112000
Nesting [handler_rapid]                     3674 ns         3610 ns       194783
Nesting [handler_boost]                     3043 ns         3048 ns       235789
Nesting [generator_boost]                   3451 ns         2930 ns       224000
Nesting [stream_parser]                     3426 ns         3223 ns       213333
Updates_1 [ignore_handler_rapid]            1322 ns         1290 ns       448000
Updates_1 [ignore_handler_boost]             667 ns          600 ns      1120000
Updates_1 [dom_rapid]                       2854 ns         2846 ns       263529
Updates_1 [dom_boost]                       3830 ns         3770 ns       194783
Updates_1 [handler_rapid]                   3137 ns         3115 ns       235789
Updates_1 [handler_boost]                   2256 ns         2250 ns       298667
Updates_1 [generator_boost]                 1727 ns         1726 ns       407273
Updates_1 [stream_parser]                   1747 ns         1758 ns       373333
Updates_5 [ignore_handler_rapid]           11197 ns        11230 ns        64000
Updates_5 [ignore_handler_boost]            5765 ns         5720 ns       112000
Updates_5 [dom_rapid]                      24577 ns        24554 ns        28000
Updates_5 [dom_boost]                      46429 ns        44922 ns        16000
Updates_5 [handler_rapid]                  28546 ns        29646 ns        26353
Updates_5 [handler_boost]                  22498 ns        20926 ns        29867
Updates_5 [generator_boost]                16935 ns        16113 ns        40727
Updates_5 [stream_parser]                  19543 ns        18032 ns        40727
Updates_10 [ignore_handler_rapid]         127820 ns       128348 ns         5600
Updates_10 [ignore_handler_boost]          60810 ns        57812 ns        10000
Updates_10 [dom_rapid]                    344411 ns       345346 ns         2036
Updates_10 [dom_boost]                    549551 ns       515625 ns         1000
Updates_10 [handler_rapid]                413754 ns       417150 ns         1723
Updates_10 [handler_boost]                340590 ns       341797 ns         2240
Updates_10 [generator_boost]              338468 ns       336967 ns         2133
Updates_10 [stream_parser]                352408 ns       344905 ns         1948
Updates_50 [ignore_handler_rapid]         256235 ns       256319 ns         2987
Updates_50 [ignore_handler_boost]         119883 ns       119275 ns         4978
Updates_50 [dom_rapid]                    686371 ns       662667 ns          896
Updates_50 [dom_boost]                   1059138 ns      1049805 ns          640
Updates_50 [handler_rapid]                771291 ns       732422 ns          896
Updates_50 [handler_boost]                654745 ns       655692 ns         1120
Updates_50 [generator_boost]              673759 ns       571987 ns         1120
Updates_50 [stream_parser]                703937 ns       683594 ns         1120
Updates_100 [ignore_handler_rapid]       1250325 ns      1227679 ns          560
Updates_100 [ignore_handler_boost]        558612 ns       562500 ns         1000
Updates_100 [dom_rapid]                  3539821 ns      3445513 ns          195
Updates_100 [dom_boost]                  5276437 ns      5161830 ns          112
Updates_100 [handler_rapid]              3623177 ns      3491620 ns          179
Updates_100 [handler_boost]              2802416 ns      2720424 ns          224
Updates_100 [generator_boost]            2866679 ns      2761044 ns          249
Updates_100 [stream_parser]              3104064 ns      2979343 ns          236
RawTree [ignore_handler_rapid]           4114039 ns      4087936 ns          172
RawTree [ignore_handler_boost]           1626373 ns      1612408 ns          407
RawTree [dom_rapid]                     15487050 ns     15000000 ns           50
RawTree [dom_boost]                     40888368 ns     34539474 ns           19
RawTree [handler_rapid]                 13455346 ns     13437500 ns           50
RawTree [handler_boost]                 12426234 ns     11160714 ns           56
RawTree [generator_boost]               13246568 ns     13392857 ns           56
RawTree [stream_parser]                 14016544 ns     13888889 ns           45
RawUpdates_1 [ignore_handler_rapid]          663 ns          656 ns      1120000
RawUpdates_1 [ignore_handler_boost]          247 ns          249 ns      2635294
RawUpdates_1 [dom_rapid]                    1886 ns         1855 ns       320000
RawUpdates_1 [dom_boost]                    2512 ns         2511 ns       248889
RawUpdates_1 [handler_rapid]                1800 ns         1800 ns       373333
RawUpdates_1 [handler_boost]                1495 ns         1500 ns       448000
RawUpdates_1 [generator_boost]              1095 ns         1099 ns       640000
RawUpdates_1 [stream_parser]                1102 ns         1088 ns       560000
RawUpdates_5 [ignore_handler_rapid]        54230 ns        54688 ns        10000
RawUpdates_5 [ignore_handler_boost]        23158 ns        23438 ns        28000
RawUpdates_5 [dom_rapid]                  182351 ns       181370 ns         3446
RawUpdates_5 [dom_boost]                  327843 ns       329641 ns         2133
RawUpdates_5 [handler_rapid]              208079 ns       209961 ns         3200
RawUpdates_5 [handler_boost]              180742 ns       175797 ns         3733
RawUpdates_5 [generator_boost]            202196 ns       200195 ns         3200
RawUpdates_5 [stream_parser]              215453 ns       214844 ns         3200
RawUpdates_10 [ignore_handler_rapid]      159587 ns       153460 ns         4480
RawUpdates_10 [ignore_handler_boost]       61371 ns        61384 ns        11200
RawUpdates_10 [dom_rapid]                 512171 ns       516183 ns         1120
RawUpdates_10 [dom_boost]                 848075 ns       854492 ns          896
RawUpdates_10 [handler_rapid]             558574 ns       562500 ns         1000
RawUpdates_10 [handler_boost]             478599 ns       464965 ns         1445
RawUpdates_10 [generator_boost]           449346 ns       453424 ns         1723
RawUpdates_10 [stream_parser]             499879 ns       450017 ns         1493
RawUpdates_50 [ignore_handler_rapid]      493931 ns       497405 ns         1445
RawUpdates_50 [ignore_handler_boost]      200952 ns       199507 ns         3446
RawUpdates_50 [dom_rapid]                1706249 ns      1717493 ns          373
RawUpdates_50 [dom_boost]                2621037 ns      2515890 ns          236
RawUpdates_50 [handler_rapid]            1810944 ns      1804361 ns          407
RawUpdates_50 [handler_boost]            1557774 ns      1569475 ns          448
RawUpdates_50 [generator_boost]          1447805 ns      1395089 ns          448
RawUpdates_50 [stream_parser]            1571612 ns      1569475 ns          448
RawUpdates_100 [ignore_handler_rapid]     830273 ns       819615 ns          896
RawUpdates_100 [ignore_handler_boost]     343406 ns       329641 ns         2133
RawUpdates_100 [dom_rapid]               3211861 ns      2859933 ns          224
RawUpdates_100 [dom_boost]               4417824 ns      4199219 ns          160
RawUpdates_100 [handler_rapid]           3050969 ns      3007629 ns          213
RawUpdates_100 [handler_boost]           2647701 ns      2648305 ns          236
RawUpdates_100 [generator_boost]         2686438 ns      2635542 ns          249
RawUpdates_100 [stream_parser]           2888855 ns      2761044 ns          249
```
