### PR TITLE
fix: Correct command parsing with arguments

### DIFF
--- a/src/bot.cpp
+++ b/src/bot.cpp
@@ -48,12 +48,14 @@ static constexpr std::string_view parse_command(std::string_view text) {
     return "";
   text.remove_prefix(1);
   auto index = text.find_first_of(" \n\t");
-  return text.substr(0, index - 1);
+  return text.substr(0, index);
 }
 
 static_assert(parse_command("fdsfsf") == "");
 static_assert(parse_command("/start") == "start");
 static_assert(parse_command("   \t\n/start") == "start");
+static_assert(parse_command("/start arg1 arg2") == "start");
+static_assert(parse_command("  \n/command  ") == "command");
 
 dd::channel<api::Update> bot::updates(long_poll_options options) {
   dd::channel chan = long_poll(api, std::move(options));

--- a/src/net/asio_tls_transport.cpp
+++ b/src/net/asio_tls_transport.cpp
@@ -7,7 +7,7 @@ namespace tgbm {
 asio_tls_transport::asio_tls_transport(tcp_connection_options opts)
     : io_ctx(1), tcp_options(std::move(opts)) {
   if (tcp_options.disable_ssl_certificate_verify)
-    TGBM_LOG_WARN("SSL veriication for http2 client disabled");
+    TGBM_LOG_WARN("SSL verification for http2 client disabled");
 }
 
 dd::task<any_connection> asio_tls_transport::create_connection(std::string_view host, deadline_t deadline) {


### PR DESCRIPTION
**Ключевой момент**: неправильный парсинг команды при аргументах.

При переходе по ссылке с аргументами (как будто query-параметры, но не совсем), к примеру, https://t.me/x?start=helloworld результат парсинга команды будет _"/star"_

Было:
```cpp
return text.substr(0, index - 1);

// NEW
// FAIL: static_assert(parse_command("/start arg1 arg2") == "start");
// FAIL: static_assert(parse_command("  \n/command  ") == "command");
```
Стало:
```cpp
return text.substr(0, index);
```